### PR TITLE
Enable FunnyQT solution in ScalabilityMeasurements

### DIFF
--- a/examples/familiestopersons/BenchmarxFamiliesToPersons/src/org/benchmarx/examples/familiestopersons/testsuite/scalability/ScalabilityMeasurements.java
+++ b/examples/familiestopersons/BenchmarxFamiliesToPersons/src/org/benchmarx/examples/familiestopersons/testsuite/scalability/ScalabilityMeasurements.java
@@ -4,6 +4,7 @@ import org.benchmarx.BXTool;
 import org.benchmarx.examples.familiestopersons.implementations.bigul.BiGULFamiliesToPersons;
 import org.benchmarx.examples.familiestopersons.implementations.bxtend.UbtXtendFamiliesToPersons;
 import org.benchmarx.examples.familiestopersons.implementations.emoflon.EMoflonFamiliesToPersons;
+import org.benchmarx.examples.familiestopersons.implementations.funnyqt.FunnyQTFamiliesToPerson;
 import org.benchmarx.examples.familiestopersons.implementations.medini.MediniQVTFamiliesToPersons;
 import org.benchmarx.examples.familiestopersons.testsuite.Decisions;
 import org.benchmarx.util.BXToolTimer;
@@ -21,6 +22,7 @@ public class ScalabilityMeasurements {
 	private static final BXTool<FamilyRegister, PersonRegister, Decisions> tool2 = new EMoflonFamiliesToPersons();
 	private static final BXTool<FamilyRegister, PersonRegister, Decisions> tool3 = new MediniQVTFamiliesToPersons();
 	private static final BXTool<FamilyRegister, PersonRegister, Decisions> tool4 = new UbtXtendFamiliesToPersons();
+	private static final BXTool<FamilyRegister, PersonRegister, Decisions> tool5 = new FunnyQTFamiliesToPerson();
 	
 	private static final String DELIMITER = ",";
 	private static final String UNIT = "";
@@ -33,6 +35,7 @@ public class ScalabilityMeasurements {
 	private BXToolTimer<FamilyRegister, PersonRegister, Decisions> timer2;
 	private BXToolTimer<FamilyRegister, PersonRegister, Decisions> timer3;
 	private BXToolTimer<FamilyRegister, PersonRegister, Decisions> timer4;
+	private BXToolTimer<FamilyRegister, PersonRegister, Decisions> timer5;
 	
 	public ScalabilityMeasurements(int numberOfFamilies, int noOfChildren, int repeat) {
 		this.NO_OF_FAMILIES = numberOfFamilies;
@@ -48,6 +51,7 @@ public class ScalabilityMeasurements {
 		timer2 = new BXToolTimer<>(tool2, repeat);
 		timer3 = new BXToolTimer<>(tool3, repeat);;
 		timer4 = new BXToolTimer<>(tool4, repeat);
+		timer5 = new BXToolTimer<>(tool5, repeat);
 	}
 	
 	public void createPersons(PersonRegister register){
@@ -115,7 +119,8 @@ public class ScalabilityMeasurements {
 		System.out.print(timer1.timeSourceEditFromScratchInS(this::createFamiliesWithMembers) + UNIT + DELIMITER);
 		System.out.print(timer2.timeSourceEditFromScratchInS(this::createFamiliesWithMembers) + UNIT + DELIMITER);
 		System.out.print(timer3.timeSourceEditFromScratchInS(this::createFamiliesWithMembers) + UNIT + DELIMITER);
-		System.out.print(timer4.timeSourceEditFromScratchInS(this::createFamiliesWithMembers) + UNIT);
+		System.out.print(timer4.timeSourceEditFromScratchInS(this::createFamiliesWithMembers) + UNIT + DELIMITER);
+		System.out.print(timer5.timeSourceEditFromScratchInS(this::createFamiliesWithMembers) + UNIT);
 		System.out.println();
 	}
 	
@@ -125,6 +130,7 @@ public class ScalabilityMeasurements {
 		System.out.print(timer2.timeTargetEditFromScratchInS(this::createPersons) + UNIT + DELIMITER);
 		System.out.print(timer3.timeTargetEditFromScratchInS(this::createPersons) + UNIT + DELIMITER);
 		System.out.print(timer4.timeTargetEditFromScratchInS(this::createPersons) + UNIT + DELIMITER);
+		System.out.print(timer5.timeTargetEditFromScratchInS(this::createPersons) + UNIT);
 		System.out.println();
 	}
 	
@@ -134,6 +140,7 @@ public class ScalabilityMeasurements {
 		System.out.print(timer2.timeSourceEditAfterSetUpInS(this::createFamiliesWithMembers, this::createOneFamilyMember) + UNIT + DELIMITER);
 		System.out.print(timer3.timeSourceEditAfterSetUpInS(this::createFamiliesWithMembers, this::createOneFamilyMember) + UNIT + DELIMITER);
 		System.out.print(timer4.timeSourceEditAfterSetUpInS(this::createFamiliesWithMembers, this::createOneFamilyMember) + UNIT + DELIMITER);
+		System.out.print(timer5.timeSourceEditAfterSetUpInS(this::createFamiliesWithMembers, this::createOneFamilyMember) + UNIT);
 		System.out.println();
 	}
 	
@@ -141,8 +148,9 @@ public class ScalabilityMeasurements {
 		System.out.print(NO_OF_ELEMENTS + DELIMITER);
 		System.out.print(timer1.timeTargetEditAfterSetUpInS(this::createPersons, this::createOnePerson) + UNIT + DELIMITER);
 		System.out.print(timer2.timeTargetEditAfterSetUpInS(this::createPersons, this::createOnePerson) + UNIT + DELIMITER);
-		System.out.print(timer3.timeTargetEditAfterSetUpInS(this::createPersons, this::createOnePerson) + UNIT);
+		System.out.print(timer3.timeTargetEditAfterSetUpInS(this::createPersons, this::createOnePerson) + UNIT + DELIMITER);
 		System.out.print(timer4.timeTargetEditAfterSetUpInS(this::createPersons, this::createOnePerson) + UNIT + DELIMITER);
+		System.out.print(timer5.timeTargetEditAfterSetUpInS(this::createPersons, this::createOnePerson) + UNIT);
 		System.out.println();
 	}
 
@@ -162,12 +170,17 @@ public class ScalabilityMeasurements {
 		new ScalabilityMeasurements(numOfFamilies, numOfChildren, repetitions).runIncrBWDMeasurements();
 	}
 	
-	private static void printHeader(String title) {
-		System.out.println("------------------");
-		System.out.println(title);
-		System.out.println("------------------");
-		System.out.println("model size (# of nodes and edges)" + DELIMITER +  tool1.getName() + DELIMITER +  tool2.getName() + DELIMITER +  tool3.getName() + DELIMITER + tool4.getName());
-	}
+    private static void printHeader(String title) {
+        System.out.println("------------------");
+        System.out.println(title);
+        System.out.println("------------------");
+        System.out.println("model size (# of nodes and edges)" + DELIMITER
+                + tool1.getName() + DELIMITER 
+                + tool2.getName() + DELIMITER
+                + tool3.getName() + DELIMITER 
+                + tool4.getName() + DELIMITER
+                + tool5.getName());
+    }
 	
 	public static void main(String[] args) {
 		


### PR DESCRIPTION
I know I've said the last PR was my last but I just found out there's also a scalability measurements class.  So I added my FunnyQT solution there, too, and the results in comparison to the other tools are horrible.  Maybe you can extend the BXToolTimer so that it kills a tool if it doesn't finish within a given amount of time.  (E.g., run the transformation in a separate thread and call the (unsafe, deprecated) `Thread.stop()` method.)

By the way: the case description says that every solution developer should provide a SHARE image with his fork of the benchmarx project.  Is that sensible?  Wouldn't it be much better to make one SHARE image with all solutions?  I guess everyone will fork this project and have her solution integrated here with a PR anyway.